### PR TITLE
Fixes #22 - added an optional env var 'TARGET_DIR'

### DIFF
--- a/.sample-env
+++ b/.sample-env
@@ -1,5 +1,6 @@
 export REPO_OWNER=
 export REPO_NAME=
+export TARGET_DIR=
 export GITHUB_TOKEN=
 export GOOGLE_API_CLIENT_EMAIL=
 export GOOGLE_API_PRIVATE_KEY=


### PR DESCRIPTION
Fixes #22 

For example...

To commit the `sessions.json` to a dir on a repo, e.g., `2016-london` on https://github.com/mozilla/mofo-allhands, set env var `TARGET_DIR` to 2016-london
